### PR TITLE
Fix Node CI issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '22.4'
       - name: Clean install the npm project
         run: npm ci
       # TODO


### PR DESCRIPTION
See issue #32 

Changes
- Pin node to [version 22.4](https://nodejs.org/download/release/)